### PR TITLE
fix "NameError: name 'mysim_N_512' is not defined"

### DIFF
--- a/quflow/simulation.py
+++ b/quflow/simulation.py
@@ -567,7 +567,7 @@ if not args.animate:
 
 # Create animation
 if not args.simulate:
-    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'])
+    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'], title=mysim['title'])
 
 
 """.format(os.path.basename(sim.filename), sim['prerun'])

--- a/quflow/simulation.py
+++ b/quflow/simulation.py
@@ -482,7 +482,7 @@ class QuSimulation(object):
 # RUNFILE CREATION FUNCTION
 # -------------------------
 
-def create_runfile(sim, runfilename: str = None):
+def create_runfile(sim, runfilename: str = None, title=None):
     """
     Create cluster runfile from QuSimulation object.
 
@@ -567,7 +567,7 @@ if not args.animate:
 
 # Create animation
 if not args.simulate:
-    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'], title=mysim['title'])
+    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'], title='"""+title+"""')
 
 
 """.format(os.path.basename(sim.filename), sim['prerun'])

--- a/quflow/simulation.py
+++ b/quflow/simulation.py
@@ -519,7 +519,7 @@ else:
     print("Running on CPU")
 
 parser = argparse.ArgumentParser()
-parser.add_argument("-f", "--filename", help="HDF5 simfile", type=str, default={}) 
+parser.add_argument("-f", "--filename", help="HDF5 simfile", type=str, default="{}") 
 parser.add_argument("-a", "--animate", help="Only create animation.", action="store_true")
 parser.add_argument("-s", "--simulate", help="Only simulate.", action="store_true")
 parser.add_argument("-t", "--simtime", help="Total simulation time.", type=float)

--- a/quflow/simulation.py
+++ b/quflow/simulation.py
@@ -482,7 +482,7 @@ class QuSimulation(object):
 # RUNFILE CREATION FUNCTION
 # -------------------------
 
-def create_runfile(sim, runfilename: str = None, title=None):
+def create_runfile(sim, runfilename: str = None):
     """
     Create cluster runfile from QuSimulation object.
 
@@ -567,7 +567,7 @@ if not args.animate:
 
 # Create animation
 if not args.simulate:
-    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'], title='"""+title+"""')
+    qf.create_animation(args.filename.replace(".hdf5", ".mp4"), mysim['fun'])
 
 
 """.format(os.path.basename(sim.filename), sim['prerun'])


### PR DESCRIPTION
Something went wrong in `create_runfile(...)` and `mysim_runfile.py` was created with the line
`parser.add_argument("-f", "--filename", help="HDF5 simfile", type=str, default=mysim_N_512.hdf5)` 
that should have been
`parser.add_argument("-f", "--filename", help="HDF5 simfile", type=str, default="mysim_N_512.hdf5")` 

I reverted the `default=...` part in `create_runfile(...)` to how it was last commit and it seems to work.